### PR TITLE
fix for path to hash.c -> hashfile.c and metalink.c in POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,7 +8,7 @@ libmget/cookie.c
 libmget/css.c
 libmget/css_tokenizer.c
 libmget/decompressor.c
-src/hash.c
+libmget/hashfile.c
 libmget/hashmap.c
 libmget/http.c
 libmget/iri.c
@@ -16,7 +16,7 @@ src/job.c
 libmget/log.c
 src/log.c
 libmget/md5.c
-src/metalink.c
+libmget/metalink.c
 src/mget.c
 libmget/net.c
 src/options.c


### PR DESCRIPTION
## it was moved into libmget/ folder

$ make
can't find hash.c.

make[3]: **\* No rule to make target ../src/hash.c', needed bymget.pot-update'. Stop.
